### PR TITLE
Reporter Service

### DIFF
--- a/.github/workflows/dockerimage-reporter.yml
+++ b/.github/workflows/dockerimage-reporter.yml
@@ -1,0 +1,35 @@
+# Reference:https://github.com/marketplace/actions/build-and-push-docker-images
+name: Reporter Docker Image Build
+
+on:
+  push:
+    branches: [ master, beta, develop ]
+
+jobs:
+
+  push_to_registries:
+    name: Pushes Reporter Docker image to Dockerhub and Github Registry
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    - name: Push to Docker Hub
+      uses: docker/build-push-action@v1
+      with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: thelusina/volt-ci-reporter
+          dockerfile: "Dockerfile.reporter"
+          tag_with_ref: true
+
+    - name: Push to GitHub Packages
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        repository: brianlusina/volt-ci/volt-ci-reporter
+        dockerfile: "Dockerfile.reporter"
+        tag_with_ref: true

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ pip-selfcheck.json
 .envrc
 .commit_id
 test_results
+results

--- a/Dockerfile.reporter
+++ b/Dockerfile.reporter
@@ -1,0 +1,14 @@
+FROM python:3.8.1-alpine3.11
+
+WORKDIR /usr/src/app
+
+COPY Pipfile Pipfile
+COPY run_reporter_service.py run_reporter_service.py
+COPY ci/__init__.py ci/__init__.py
+COPY ci/reporter ci/reporter
+COPY ci/logger.py ci/logger.py
+COPY ci/utils.py ci/utils.py
+
+RUN pip install loguru
+
+EXPOSE ${PORT}

--- a/README.md
+++ b/README.md
@@ -107,16 +107,24 @@ It handles several commands, most are listed in the dispatch_handler.py source c
 
     This is used to dispatch any new commit_ids to the test runners as recevied from the repo observer
 
-4. _results_
-
-    This is used by test runners to communicate results of running tests against the given commit_id
-
 ### Test Runner
 
 This component actually runs the tests as discovered in a repository. It will receive commands from dispatcher server
 with a commit id and will begin running tests for that repository. This will communicate with dispatcher server every 5 seconds to check if it is still alive. If the response from dispatcher server is not OK, the test runner server will terminate & shutdown to conserve resources as it will not have anywhere to report test results nor receive commands to run.
 
 The implementation for a TCP server is similar to the Dispatcher server with new connection requests being handled on a separate thread.
+
+#### Reporter Service
+
+This is used to report test results as received from test runners. This can be used to display test results to clients/users
+
+1. _status_
+
+    This is used to check the status of the reporter service
+
+2. _results_
+
+    This is used by test runners to communicate results of running tests against the given commit_id
 
 #### Running the code
 
@@ -133,6 +141,14 @@ python run_test_runner.py --repo /path/too/repo
 ```
 
 > This will assigning itself a port in the range of 8900-9000. You can run as many test runners as possible
+
+In a new shell, we start the reporter service
+
+``` bash
+python run_reporter_service.py
+```
+
+> Refer to the CLI options, this will start with all defaults applied
 
 now start the repo observer
 

--- a/ci/reporter/__init__.py
+++ b/ci/reporter/__init__.py
@@ -1,0 +1,32 @@
+"""
+This is the Reporter Service.
+
+This is responsible for Reporting test results as received from test runners
+"""
+import time
+from socket import socket, AF_INET, SOCK_STREAM
+from threading import Thread
+
+from ci.logger import logger
+from ci.utils import communicate
+
+
+from .threading_tcp_server import ThreadingTCPServer
+from .reporter_handler import ReporterHandler
+
+
+def reporter_service(host, port):
+    """
+    Entry point to Reporter Service
+    """
+
+    server = ThreadingTCPServer((host, int(port)), ReporterHandler)
+
+    logger.info(f"Reporter Service running on address {host}:{port}")
+
+    try:
+        # Run forever unless stopped
+        server.serve_forever()
+    except (KeyboardInterrupt, Exception):
+        # in case it is stopped or encounters any error
+        server.dead = True

--- a/ci/reporter/threading_tcp_server.py
+++ b/ci/reporter/threading_tcp_server.py
@@ -1,0 +1,22 @@
+"""
+Custom Socket TCP Server to handle mutliple connections. Typically TCP servers can only handle
+1 connection at a time. This is not ideal in this case, because there could be an instance where
+a test runner has a connection open with the dispatcher & a connection comes in from the repo_observer.
+The repo observer has to wait for the initial connection to disconnect & close, before it can proceed
+with its request.
+
+In order to handle multiple requests, this adds threading ability to the SocketServer in order to service
+multiple connections on different threads.
+"""
+import socketserver
+
+
+class ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    """
+    Custom Threading TCP Server which ensures that there is continuous, ordered streams
+    of data between servers. UDP does not ensure this
+
+    :cvar dead: indicate to other threads that we ain't alive
+    """
+
+    dead = False

--- a/ci/test_runner/__init__.py
+++ b/ci/test_runner/__init__.py
@@ -47,13 +47,19 @@ def dispatcher_checker(server):
                 return
 
 
-def test_runner_server(host, port, repo, dispatcher_host, dispatcher_port):
+def test_runner_server(
+    host, port, repo, dispatcher_host, dispatcher_port, reporter_host, reporter_port
+):
     """
     This invokes the Test Runner server.
 
     :param host: host to use
     :param port: port to use
     :param repo: repository to watch
+    :param dispatcher_host: Dispatcher host
+    :param dispatcher_port: Dispatcher Port
+    :param reporter_host: Reporter Host
+    :param reporter_port: Reporter Port
     """
     range_start = 8900
 
@@ -95,6 +101,7 @@ def test_runner_server(host, port, repo, dispatcher_host, dispatcher_port):
     server.repo_folder = repo
 
     server.dispatcher_server = {"host": dispatcher_host, "port": dispatcher_port}
+    server.reporter_service = {"host": reporter_host, "port": reporter_port}
     response = communicate(
         server.dispatcher_server["host"],
         int(server.dispatcher_server["port"]),

--- a/ci/test_runner/threading_tcp_server.py
+++ b/ci/test_runner/threading_tcp_server.py
@@ -6,12 +6,14 @@ class ThreadingTCPServer(ThreadingMixIn, TCPServer):
     Custom TCP Server which allows spawning of threads to allow requests to be handled on different threads
 
     :cvar dispatcher_server: Holds the dispatcher server host/port information
+    :cvar reporter_service: Holds the dispatcher server host/port information
     :cvar last_communication: Keeps track of last communication from dispatcher
     :cvar busy: Status flag indicating whether the test runner server is currently busy
     :cvar dead: Status flag indicating whether this test runner server is dead/unresponsive
     """
 
     dispatcher_server = None
+    reporter_service = None
     last_communication = None
     busy = False
     dead = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,4 +33,14 @@ services:
     environment:
       REPOSITORY: ${REPOSITORY}
     command: ["python", "run_test_runner.py", "--repo", "$REPOSITORY", "--dispatcher-server", "observer:8000"]
- 
+
+  reporter:
+    build: 
+      context: .
+      dockerfile: Dockerfile.reporter
+    container_name: reporter
+    ports: 
+      - 8555:8555
+    environment:
+      PORT: "8555"
+    command: ["python", "run_reporter_service.py", "--port", "$PORT"]

--- a/run_reporter_service.py
+++ b/run_reporter_service.py
@@ -1,0 +1,29 @@
+import argparse
+from ci.reporter import reporter_service
+
+
+def run_reporter():
+    """
+    Entry point to reporter service
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--host",
+        help="Reporter's host, defaults to localhost",
+        default="localhost",
+        action="store",
+    )
+    parser.add_argument(
+        "--port",
+        help="Reporter's port, defaults to 8555",
+        default=8555,
+        action="store",
+    )
+
+    args = parser.parse_args()
+
+    reporter_service(args.host, int(args.port))
+
+
+if __name__ == "__main__":
+    run_reporter()

--- a/run_test_runner.py
+++ b/run_test_runner.py
@@ -27,6 +27,12 @@ def run_test_runner():
         action="store",
     )
     parser.add_argument(
+        "--reporter-service",
+        help="reporter host:port, by default it uses localhost:8555",
+        default="localhost:8555",
+        action="store",
+    )
+    parser.add_argument(
         "--repo",
         metavar="REPO",
         type=str,
@@ -39,9 +45,16 @@ def run_test_runner():
     runner_port = args.port
     repository = args.repo
     dispatcher_host, dispatcher_port = args.dispatcher_server.split(":")
+    reporter_host, reporter_port = args.reporter_service.split(":")
 
     test_runner_server(
-        runner_host, runner_port, repository, dispatcher_host, dispatcher_port
+        runner_host,
+        runner_port,
+        repository,
+        dispatcher_host,
+        dispatcher_port,
+        reporter_host,
+        reporter_port,
     )
 
 


### PR DESCRIPTION
## Description

CI component Reporter Service to display test results if needed by requesting clients or users. As
of now, this is not exposed via any API. However, this reporter service will be receiving test
results from test runner instances & will write them to a file or display them (feature not
available). This takes away this feature from dispatcher service, allowing more decoupling & an
easier role for dispatcher. Letting the Dispatcher Server only handling dispatching commit_ids to
test runners & reporter service to handle test results

Other Minor changes:
1. Brief doc on Reporter Service
2. add temp file for test results
3. Docker build action for building Docker image for Reporter Service
4. Instructions to build & run Reporter Service

## How can we test this?

1. Run dispatcher
2. Run test_runner(s)
3. Run repo observer
4. Run reporter service

All the run commands are available at root of project. These will run with default CLI options

## Checklist:

- [x] I have not introduced new bugs :rofl:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors